### PR TITLE
Compile under Linux / IDA 7.2

### DIFF
--- a/hexagon/ana.cpp
+++ b/hexagon/ana.cpp
@@ -143,13 +143,15 @@ static uint32_t new_value( uint32_t nt, bool hvx = false )
             // avoid calling decode_insn()
             memset( &temp, 0, sizeof(temp) );
             temp.ea = ea;
-            if( !ana( temp ) ) goto __cleanup;
+            if( !ana( temp ) ) {s_pkt_start = saved_pkt_start, s_insn_ea = saved_ea;
+    return result;}
             // skip scalars when calculating distances for vectors
             if( hvx && !is_hvx( temp ) ) ++offset;
         }
         if( --offset == 0 ) break;
         // couldn't find producer?
-        if( ea <= saved_pkt_start ) goto __cleanup;
+        if( ea <= saved_pkt_start ) {s_pkt_start = saved_pkt_start, s_insn_ea = saved_ea;
+    return result;}
     }
     // we got the producer, find out the operand
     // TODO: check if duplexes have to be supported
@@ -170,7 +172,6 @@ static uint32_t new_value( uint32_t nt, bool hvx = false )
             result = temp.ops[i + (nt & 1)].reg;
     }
 
-__cleanup:
     // restore globals
     s_pkt_start = saved_pkt_start, s_insn_ea = saved_ea;
     return result;

--- a/hexagon/common.h
+++ b/hexagon/common.h
@@ -11,6 +11,7 @@
 #include "ieee.h"
 #include "typeinf.hpp"
 #include "ins.h"
+#define _countof(a) (sizeof(a)/sizeof(*(a)))
 
 #define IN_RANGE(u,lo,hi)           (uint32_t((u) - (lo)) <= ((hi) - (lo)))
 

--- a/hexagon/emu.cpp
+++ b/hexagon/emu.cpp
@@ -579,12 +579,9 @@ int hex_use_regarg_type( ea_t ea, const funcargvec_t &rargs )
 #undef JUMP_DEBUG
 #include "../jptcmn.cpp"
 
+
 struct hex_jump_pattern_t : public jump_pattern_t
 {
-    hex_jump_pattern_t( switch_info_t *_si ) : jump_pattern_t( _si, s_roots, s_depends )
-    {
-        allow_noflows = false;
-    }
     enum { rA, rB, rT, rI, rP };
     static constexpr char s_roots[] = { 1, 0 };
     static constexpr char s_depends[][2] = {
@@ -594,6 +591,11 @@ struct hex_jump_pattern_t : public jump_pattern_t
         { 0 },        // 3
         { 0 },        // 4
     };
+
+    hex_jump_pattern_t( switch_info_t *_si ) : jump_pattern_t( _si, s_roots, s_depends )
+    {
+        allow_noflows = false;
+    }
     virtual bool jpi4( void );
     virtual bool jpi3( void );
     virtual bool jpi2( void );
@@ -793,13 +795,6 @@ static jump_table_type_t is_jump_pattern( switch_info_t *si, const insn_t &insn 
           -> 3
                -> 4
 */
-struct hex_jump_pattern_t : public jump_pattern_t
-{
-    hex_jump_pattern_t( switch_info_t *si ) : jump_pattern_t( si, s_depends, rI )
-    {
-        modifying_r32_spoils_r64 = false;
-        si->flags |= SWI_HXNOLOWCASE;
-    }
     enum { rA, rB, rT, rI };
     static constexpr char s_depends[][4] = {
         { 1 },        // 0
@@ -808,6 +803,14 @@ struct hex_jump_pattern_t : public jump_pattern_t
         { 0 },        // 3
         { 0 },        // 4
     };
+
+struct hex_jump_pattern_t : public jump_pattern_t
+{
+    hex_jump_pattern_t( switch_info_t *si ) : jump_pattern_t( si, s_depends, rI )
+    {
+        modifying_r32_spoils_r64 = false;
+        si->flags |= SWI_HXNOLOWCASE;
+    }
     virtual bool jpi4( void );
     virtual bool jpi3( void );
     virtual bool jpi2( void );

--- a/hexagon/loader.cpp
+++ b/hexagon/loader.cpp
@@ -147,6 +147,7 @@ static const char* proc_relocation(
     // msg( "rel @0x%X: type=%2d, Sadd=0x%X, S=0x%X, sym=%s\n",
     //      rel_data.P, rel_data.type, rel_data.Sadd, rel_data.S, symbol->original_name );
     fixup_type_t ftype = FIXUP_OFF32;
+    fixup_data_t fd( ftype );
 
     // simple cases
     switch( rel_data.type )
@@ -157,19 +158,27 @@ static const char* proc_relocation(
     case R_HEX_JMP_SLOT:
     case R_HEX_RELATIVE:
         put_dword( rel_data.P, rel_data.Sadd );
-        goto __fixup;
+        fd.off = rel_data.Sadd;
+        fd.set( rel_data.P );
+        return NULL; // ok
     case R_HEX_16:
         put_word( rel_data.P, rel_data.Sadd );
-        goto __fixup;
+        fd.off = rel_data.Sadd;
+        fd.set( rel_data.P );
+        return NULL; // ok
     case R_HEX_8:
         put_byte( rel_data.P, rel_data.Sadd );
-        goto __fixup;
+        fd.off = rel_data.Sadd;
+        fd.set( rel_data.P );
+        return NULL; // ok
     case R_HEX_HL16:
         put_dword( rel_data.P, get_dword( rel_data.P ) |
                    apply_mask( rel_data.Sadd >> 16, LO_MASK ) );
         put_dword( rel_data.P + 4, get_dword( rel_data.P + 4 ) |
                    apply_mask( rel_data.Sadd, LO_MASK ) );
-        goto __fixup;
+        fd.off = rel_data.Sadd;
+        fd.set( rel_data.P );
+        return NULL; // ok
     }
 
     // word32 masked relocs
@@ -293,9 +302,7 @@ static const char* proc_relocation(
     word |= apply_mask( value, mask );
     put_dword( rel_data.P, word );
 
-__fixup:
     // add a fixup
-    fixup_data_t fd( ftype );
     fd.off = rel_data.Sadd;
     fd.set( rel_data.P );
     return NULL; // ok


### PR DESCRIPTION
Fix to compile using IDA 7.2 SDK and Ubuntu 20.10 under Linux. Tested to work with IDA Pro 7.2 Linux.

Compiling using IDA 7.5 fails due to the processor structure being changed.