### PR TITLE
Updated to SDK 7.6

### DIFF
--- a/hexagon/common.h
+++ b/hexagon/common.h
@@ -56,7 +56,13 @@ static inline uchar inf_get_cc_size_e() { return inf.cc.size_e; }
 
 #endif
 
-//IDAv7.6+ multiple instance support.
+#if IDA_SDK_VERSION < 750
+
+struct procmod_t {};
+
+#endif
+
+//IDAv7.5+ multiple instance support.
 //Older versions can instantiate a single object at start and direct all calls to it. TODO: does procmod_t exist in older versions?
 struct hexagon_t : public procmod_t {
     //convert all globals to members
@@ -110,6 +116,14 @@ struct hexagon_t : public procmod_t {
 
 };
 
+#if IDA_SDK_VERSION >= 750
+
 static inline uint16_t out_get_idpflags(outctx_t &ctx) {  return static_cast<hexagon_t *>(ctx.procmod)->idpflags; }
 extern int data_id;
 
+#else
+
+extern hexagon_t procmod;
+static inline uint16_t out_get_idpflags(outctx_t &ctx) {  return procmod.idpflags; }
+
+#endif

--- a/hexagon/elf_proc_def.cpp
+++ b/hexagon/elf_proc_def.cpp
@@ -1,0 +1,137 @@
+//ldr/elf.h/proc_def_t reimplementation
+
+#include "common.h"
+#include "../../ldr/elf/elfbase.h"
+#include "../../ldr/elf/elf.h"
+
+proc_def_t::proc_def_t(elf_loader_t &_ldr, reader_t &_reader) : ldr{_ldr}, reader{_reader} {}
+
+bool proc_def_t::proc_supports_relocs() const { return true; }
+
+const char *proc_def_t::proc_handle_reloc(
+    const rel_data_t &rel_data,
+    const sym_rel *symbol,
+    const elf_rela_t *reloc,
+    reloc_tools_t *tools) { return 0; }
+
+bool proc_def_t::proc_create_got_offsets(
+    const elf_shdr_t *gotps,
+    reloc_tools_t *tools) { return false; }
+
+bool proc_def_t::proc_perform_patching(
+    const elf_shdr_t *plt,
+    const elf_shdr_t *gotps) { return false; }
+
+bool proc_def_t::proc_can_convert_pic_got() const { return false; }
+
+size_t proc_def_t::proc_convert_pic_got(
+    const segment_t *gotps,
+    reloc_tools_t *tools) { return 0; }
+
+// Return a bit description from e_flags and remove it.
+// This function may be called in a loop to document all bits.
+const char *proc_def_t::proc_describe_flag_bit(uint32 *e_flags) { return 0; }
+
+// called for processor-specific section types
+bool proc_def_t::proc_load_unknown_sec(Elf64_Shdr *sh, bool force) { return force; }
+
+// called for each dynamic tag. It returns NULL to continue with a
+// standard tag processing, or "" to finish tag processing, or the
+// description of the tag to show.
+const char *proc_def_t::proc_handle_dynamic_tag(const Elf64_Dyn *dyn) { return 0; }
+
+bool proc_def_t::proc_is_acceptable_image_type(ushort filetype) { return false; }
+
+// called after header loading (before load_pht/load_simage)
+void proc_def_t::proc_on_start_data_loading(elf_ehdr_t &header) {}
+
+// called after loading data from the input file
+bool proc_def_t::proc_on_end_data_loading() { return true; }
+
+void proc_def_t::proc_on_loading_symbols() {}
+
+bool proc_def_t::proc_handle_symbol(sym_rel &sym, const char *symname) { return true; }
+
+// Handle a dynamic symbol
+void proc_def_t::proc_handle_dynsym(
+    const sym_rel &symrel,
+    elf_sym_idx_t isym,
+    const char *symname) {}
+
+// 0-reaccept, 1-set name only, else: non-existing section
+int proc_def_t::proc_handle_special_symbol(
+    sym_rel *st,
+    const char *name,
+    ushort type)
+{
+    uint16 shndx = st->original.st_shndx;
+    int i=NSPEC_SEGMS;
+    switch(shndx) 
+    { 
+        case SHN_UNDEF:
+            return -1; 
+        case SHN_ABS:
+            i = 2;
+            break;
+        case SHN_COMMON:
+            i = 1;
+            break;
+        default:
+            if (shndx<SHN_LORESERVE)
+            {
+                return -1;;
+            }
+            for(int j=0; j<NSPEC_SEGMS; j++)
+            {
+                if (additional_spec_secidx[j]==shndx)
+                {
+                    i = ((type==6) && (j==0)) ? 3 : j;
+                    break;
+                }
+            }
+    }
+    if (i>=NSPEC_SEGMS) { return -1; }
+    st->original.st_shndx = ldr.spec_segms[i].shn_type;
+    return 0;
+}
+
+// called from a function should_load_segment for _every_ section.
+// It returns 'false' to skip loading of the given section.
+bool proc_def_t::proc_should_load_section(
+    const elf_shdr_t &sh,
+    elf_shndx_t idx,
+    const qstring &name) 
+{ 
+    return ((sh.sh_type==SHT_PROGBITS) || (sh.sh_flags & (SHF_WRITE | SHF_ALLOC | SHF_EXECINSTR | SHF_TLS)));
+}
+
+// called before the segment creation. It may set <sa> to the ea at
+// which a given section should be loaded. In the other case the
+// default segment ea computation is used. Also it may return 'false'
+// to skip creation of a segment for this section.
+bool proc_def_t::proc_on_create_section(
+    const elf_shdr_t &sh,
+    const qstring &name,
+    ea_t *sa) 
+{ 
+    return true; 
+}
+
+const char *proc_def_t::calc_procname(uint32 *e_flags, const char *procname) 
+{ 
+    return procname; 
+}
+
+// for some 64-bit architectures e_entry holds not a real entry point
+// but a function descriptor
+// E.g. 64-bit PowerPC ELF Application Binary Interface Supplement 1.9
+// section 4.1. ELF Header
+// "The e_entry field in the ELF header holds the address of a function
+// descriptor. This function descriptor supplies both the address of the
+// function entry point and the initial value of the TOC pointer
+// register."
+// this callback should translate this address to the real entry.
+ea_t proc_def_t::proc_adjust_entry(ea_t entry)
+{
+    return entry;
+}

--- a/hexagon/elf_proc_def.cpp
+++ b/hexagon/elf_proc_def.cpp
@@ -1,6 +1,10 @@
-//ldr/elf.h/proc_def_t reimplementation
+//v7.5+ ldr/elf.h/proc_def_t reimplementation
+
 
 #include "common.h"
+
+#if IDA_SDK_VERSION >= 750
+
 #include "../../ldr/elf/elfbase.h"
 #include "../../ldr/elf/elf.h"
 
@@ -135,3 +139,5 @@ ea_t proc_def_t::proc_adjust_entry(ea_t entry)
 {
     return entry;
 }
+
+#endif

--- a/hexagon/emu.cpp
+++ b/hexagon/emu.cpp
@@ -475,7 +475,13 @@ static bool insn_modifies_op0( uint32_t itype )
         0xfffffffe, 0xbf7fffff, 0xffffffff, 0x000539c1, 0x022d0808, 0xf1c004c0, 0xffffffff, 0xffffffff,
         0xffffffff, 0xffffffff, 0x733fffff, 0xe7ffffff, 0xffffffff, 0xfe0ffff9,
     };
-    assert( itype < _countof(mod) * 32 );
+    //assert( itype < _countof(mod) * 32 );
+	if (!(itype < (_countof(mod) * 32)))
+	{
+    	warning("insn_modifies_op0: itype %d is out of range\n",  itype);
+		return false;
+	}
+
     return (mod[ itype >> 5 ] >> (itype & 31)) & 1;
 }
 

--- a/hexagon/loader.cpp
+++ b/hexagon/loader.cpp
@@ -395,13 +395,14 @@ ssize_t loader_elf_machine( linput_t*, int machine_type, const char**, proc_def_
     // b) replace vft in the existing proc_def_t object at *p_pd
 
     // ****** WARNING: dirty hack ******:
+    /*
     static uintptr_t vft[21];
     memcpy( vft, **(uintptr_t***)p_pd, sizeof(vft) );
     vft[2] = (uintptr_t) proc_handle_reloc;
     vft[7] = (uintptr_t) proc_describe_flag_bit;
     vft[9] = (uintptr_t) proc_handle_dynamic_tag;
     **(uintptr_t***)p_pd = vft;
-
+    */
     return machine_type;
 }
 

--- a/hexagon/makefile
+++ b/hexagon/makefile
@@ -1,5 +1,6 @@
 PROC=hexagon
 O1=loader
+O2=elf_proc_def
 
 include ../module.mak
 
@@ -48,4 +49,12 @@ $(F)loader$(O) : $(I)auto.hpp $(I)bitrange.hpp $(I)bytes.hpp               \
 	          $(I)loader.hpp $(I)nalt.hpp $(I)name.hpp $(I)netnode.hpp  \
 	          $(I)offset.hpp $(I)pro.h $(I)problems.hpp $(I)range.hpp   \
 	          $(I)segment.hpp $(I)segregs.hpp $(I)typeinf.hpp           \
-	          $(I)ua.hpp $(I)xref.hpp ../idaidp.hpp common.h reg.cpp
+	          $(I)ua.hpp $(I)xref.hpp ../idaidp.hpp common.h loader.cpp
+$(F)elf_proc_def$(O) : $(I)auto.hpp $(I)bitrange.hpp $(I)bytes.hpp               \
+	          $(I)config.hpp $(I)diskio.hpp $(I)fixup.hpp $(I)fpro.h    \
+	          $(I)funcs.hpp $(I)ida.hpp $(I)idp.hpp $(I)ieee.h          \
+	          $(I)kernwin.hpp $(I)lines.hpp $(I)llong.hpp               \
+	          $(I)loader.hpp $(I)nalt.hpp $(I)name.hpp $(I)netnode.hpp  \
+	          $(I)offset.hpp $(I)pro.h $(I)problems.hpp $(I)range.hpp   \
+	          $(I)segment.hpp $(I)segregs.hpp $(I)typeinf.hpp           \
+	          $(I)ua.hpp $(I)xref.hpp ../idaidp.hpp common.h elf_proc_def.cpp

--- a/hexagon/out.cpp
+++ b/hexagon/out.cpp
@@ -24,7 +24,7 @@ void out_footer( outctx_t &ctx )
 {
     qstring nbuf = get_colored_name( inf_get_start_ea() );
     const char *name = nbuf.c_str();
-#if IDA_SDK_VERSION == 750
+#if IDA_SDK_VERSION >= 750
     asm_t &ash = ctx.ash;
 #endif
     const char *end = ash.end;
@@ -416,6 +416,7 @@ static uint32_t hex_out_predicate( outctx_t &ctx, uint32_t ptype, uint32_t op_id
 
 static uint32_t hex_out_insn( outctx_t &ctx, uint32_t itype, uint32_t flags, uint32_t op_idx )
 {
+    uint16_t idpflags = out_get_idpflags(ctx);
     // output predicate
     if( (flags & PRED_MASK) != PRED_NONE )
         op_idx = hex_out_predicate( ctx, flags & PRED_MASK, op_idx );
@@ -497,6 +498,8 @@ static bool is_single( const insn_t insn )
 }
 static void out_pkt_beg( outctx_t &ctx )
 {
+    uint16_t idpflags = out_get_idpflags(ctx);
+
     if( !(idpflags & HEX_BRACES_FOR_SINGLE) && is_single( ctx.insn ) )
         ctx.out_line( "  ", COLOR_SYMBOL );
     else if( (idpflags & HEX_OBRACE_ALONE) )
@@ -510,6 +513,8 @@ static void out_pkt_beg( outctx_t &ctx )
 
 static void out_pkt_end( outctx_t &ctx )
 {
+    uint16_t idpflags = out_get_idpflags(ctx);
+
     if( !(idpflags & HEX_BRACES_FOR_SINGLE) && is_single( ctx.insn ) )
         return;
     if( (idpflags & HEX_CBRACE_ALONE) )
@@ -533,6 +538,8 @@ static void out_pkt_end( outctx_t &ctx )
 // output an instruction and its operands
 void out_insn( outctx_t &ctx )
 {
+    uint16_t idpflags = out_get_idpflags(ctx);
+
     if( (ctx.insn.flags & INSN_PKT_BEG) )
         out_pkt_beg( ctx );
     else

--- a/hexagon/out.cpp
+++ b/hexagon/out.cpp
@@ -97,7 +97,12 @@ static void hex_out_reg( outctx_t &ctx, uint32_t reg, uint32_t flags = 0 )
     if( (flags & REG_QUAD) )
     {
         // quad registers are valid only for HVX
-        assert( IN_RANGE(reg, REG_V0, REG_V0 + 31) && ((reg - REG_V0) & 3) == 0 );
+        //assert( IN_RANGE(reg, REG_V0, REG_V0 + 31) && ((reg - REG_V0) & 3) == 0 );
+        if (!( IN_RANGE(reg, REG_V0, REG_V0 + 31) && ((reg - REG_V0) & 3) == 0 ))
+		{
+			warning("hex_out_reg: REG_QUAD %d is not HVX\n", reg);
+		}
+
         ctx.out_printf( "v%u:%u", reg + 3 - REG_V0, reg - REG_V0 );
     }
     else if( (flags & REG_DOUBLE) )
@@ -125,7 +130,12 @@ static void hex_out_reg( outctx_t &ctx, uint32_t reg, uint32_t flags = 0 )
         else
         {
             if( IN_RANGE(reg, REG_R0, REG_R0 + 31) ) {
-                assert( ((reg - REG_R0) & 1) == 0 );
+                //assert( ((reg - REG_R0) & 1) == 0 );
+                if (((reg - REG_R0) & 1) != 0 )
+				{
+					warning("hex_out_reg: REG_DOUBLE R%d is odd\n", reg-REG_R0);
+				}
+
                 ctx.out_printf( "r%u:%u", reg + 1 - REG_R0, reg - REG_R0 );
             }
             else if( IN_RANGE(reg, REG_V0, REG_V0 + 31) ) {
@@ -134,15 +144,30 @@ static void hex_out_reg( outctx_t &ctx, uint32_t reg, uint32_t flags = 0 )
                 ctx.out_printf( "v%u:%u", (reg - REG_V0) ^ 1 , reg - REG_V0 );
             }
             else if( IN_RANGE(reg, REG_C0, REG_C0 + 31) ) {
-                assert( ((reg - REG_C0) & 1) == 0 );
+                //assert( ((reg - REG_C0) & 1) == 0 );
+                if ( ((reg - REG_C0) & 1) != 0 )
+				{
+					warning("hex_out_reg: REG_DOUBLE C%d is odd\n", reg-REG_C0);
+				}
+
                 ctx.out_printf( "c%u:%u", reg + 1 - REG_C0, reg - REG_C0 );
             }
             else if( IN_RANGE(reg, REG_G0, REG_G0 + 31) ) {
-                assert( ((reg - REG_G0) & 1) == 0 );
+                //assert( ((reg - REG_G0) & 1) == 0 );
+                if ( ((reg - REG_G0) & 1) != 0 )
+				{
+					warning("hex_out_reg: REG_DOUBLE G%d is odd\n", reg-REG_G0);
+				}
+
                 ctx.out_printf( "g%u:%u", reg + 1 - REG_G0, reg - REG_G0 );
             }
             else if( IN_RANGE(reg, REG_S0, REG_S0 + 127) ) {
-                assert( ((reg - REG_S0) & 1) == 0 );
+                //assert( ((reg - REG_S0) & 1) == 0 );
+                if ( ((reg - REG_S0) & 1) != 0 )
+				{
+					warning("hex_out_reg: REG_DOUBLE S%d is odd\n", reg-REG_S0);
+				}
+
                 ctx.out_printf( "s%u:%u", reg + 1 - REG_S0, reg - REG_S0 );
             }
             else

--- a/hexagon/reg.cpp
+++ b/hexagon/reg.cpp
@@ -208,7 +208,7 @@ ssize_t idaapi hexagon_t::on_event(ssize_t notification_code, va_list va)
     }
     case processor_t::ev_get_cc_regs: {
         auto regs = va_arg( va, callregs_t* );
-        auto cc = va_arg( va, cm_t );
+        auto cc = va_argi( va, cm_t );
         hex_get_cc_regs( cc, *regs );
         return 1;
     }
@@ -223,7 +223,7 @@ ssize_t idaapi hexagon_t::on_event(ssize_t notification_code, va_list va)
     case processor_t::ev_calc_retloc: {
         auto retloc = va_arg( va, argloc_t* );
         auto rettype = va_arg( va, const tinfo_t* );
-        auto cc = va_arg( va, cm_t );
+        auto cc = va_argi( va, cm_t );
         return hex_calc_retloc( cc, *rettype, *retloc )? 1 : -1;
     }
     case processor_t::ev_use_arg_types: {


### PR DESCRIPTION
I've updated the code to run on v7.6 without VMT hacks (recreated the missing proc_def_t, subclassed the procmod_t etc) while trying to preserve the older version compatibility. The code builds with 7.6, 7.5 and 7.2 SDKs on Linux, but I don't have a 7.2 for testing. Perhaps someone could test the compatibility before merging this. Tested to run on 7.6 Linux for now.